### PR TITLE
4주차 - 예외

### DIFF
--- a/src/applicationContext.xml
+++ b/src/applicationContext.xml
@@ -12,7 +12,7 @@
         <property name="username" value="root"/>
         <property name="password" value="rkdudmysql4_"/>
     </bean>
-    <bean id="userDao" class="springbook.user.dao.UserDao">
+    <bean id="userDao" class="springbook.user.dao.UserDaoJdbc">
         <property name="dataSource" ref="dataSource"/> <!--아직 dao의 get()메서드가 dataSource를 사용하므로 지우지 않음-->
     </bean>
 </beans>

--- a/src/springbook/user/dao/DaoFactory.java
+++ b/src/springbook/user/dao/DaoFactory.java
@@ -9,8 +9,8 @@ import javax.sql.DataSource;
 @Configuration
 public class DaoFactory {
     @Bean
-    public UserDao userDao() { // 메서드의 이름이 빈의 이름이 된다.
-        UserDao userDao = new UserDao();
+    public UserDaoJdbc userDao() { // 메서드의 이름이 빈의 이름이 된다.
+        UserDaoJdbc userDao = new UserDaoJdbc();
         userDao.setDataSource(dataSource());
         return userDao;
     }

--- a/src/springbook/user/dao/UserDao.java
+++ b/src/springbook/user/dao/UserDao.java
@@ -1,81 +1,13 @@
 package springbook.user.dao;
 
-import org.springframework.dao.DataAccessException;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.PreparedStatementCreator;
-import org.springframework.jdbc.core.ResultSetExtractor;
-import org.springframework.jdbc.core.RowMapper;
 import springbook.user.domain.User;
 
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.List;
 
-public class UserDao {
-    private JdbcTemplate jdbcTemplate;
-
-    // DataSource 오브젝트는 JdbcTemplate을 생성한 후에는 사용하지 않으므로 더이상 멤버변수에 저장해두지 않아도 된다.
-    public void setDataSource(DataSource dataSource) {
-        this.jdbcTemplate = new JdbcTemplate(dataSource);
-    }
-
-    private RowMapper<User> userMapper = new RowMapper<User>() {
-        @Override
-        public User mapRow(ResultSet rs, int rowNum) throws SQLException {
-            User user = new User();
-            user.setId(rs.getString("id"));
-            user.setName(rs.getString("name"));
-            user.setPassword(rs.getString("password"));
-            return user;
-        }
-    };
-
-
-    public void add(final User user) throws SQLException {
-        this.jdbcTemplate.update("insert into users(id, name, password) values(?, ? , ?)",
-                user.getId(), user.getName(), user.getPassword());
-    }
-
-
-    public User get(String id) throws SQLException {
-        return this.jdbcTemplate.queryForObject("select * from users where id = ?", new Object[]{id}, userMapper);
-    }
-
-    public List<User> getAll() {
-        return this.jdbcTemplate.query("select * from users order by id", userMapper);
-    }
-
-
-    public void deleteAll() throws SQLException {
-        this.jdbcTemplate.update(new PreparedStatementCreator() {
-            @Override
-            public PreparedStatement createPreparedStatement(Connection con) throws SQLException {
-                return con.prepareStatement("delete from users");
-            }
-        });
-
-//        미리 준비된 콜백을 만들어서 템플릿을 호출하는 것까지 한번에 해주는 메서드가 존재한다.
-//        this.jdbcTemplate.update("delete from users");
-    }
-
-    public int getCount() throws SQLException {
-        // 원래 getCount() 메소드에 있던 코드 중에서 변하는 부분만 콜백으로 만들어져서 제공된다고 생각하면 이해하기 쉽다.
-        return this.jdbcTemplate.query(new PreparedStatementCreator() {
-            @Override
-            public PreparedStatement createPreparedStatement(Connection con) throws SQLException {
-                return con.prepareStatement("select count(*) from users");
-            }
-        }, new ResultSetExtractor<Integer>() {
-            @Override
-            public Integer extractData(ResultSet rs) throws SQLException, DataAccessException {
-                rs.next();
-                return rs.getInt(1);
-            }
-        });
-//        이렇게도 할 수 있다.
-//        return this.jdbcTemplate.queryForObject("select count(*) from users", Integer.class);
-    }
+public interface UserDao {
+    void add(User user);
+    User get(String id);
+    List<User> getAll();
+    void deleteAll();
+    int getCount();
 }

--- a/src/springbook/user/dao/UserDaoJdbc.java
+++ b/src/springbook/user/dao/UserDaoJdbc.java
@@ -1,0 +1,81 @@
+package springbook.user.dao;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCreator;
+import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.RowMapper;
+import springbook.user.domain.User;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class UserDaoJdbc implements UserDao {
+    private JdbcTemplate jdbcTemplate;
+
+    // DataSource 오브젝트는 JdbcTemplate을 생성한 후에는 사용하지 않으므로 더이상 멤버변수에 저장해두지 않아도 된다.
+    public void setDataSource(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    private RowMapper<User> userMapper = new RowMapper<User>() {
+        @Override
+        public User mapRow(ResultSet rs, int rowNum) throws SQLException {
+            User user = new User();
+            user.setId(rs.getString("id"));
+            user.setName(rs.getString("name"));
+            user.setPassword(rs.getString("password"));
+            return user;
+        }
+    };
+
+
+    public void add(final User user) {
+        this.jdbcTemplate.update("insert into users(id, name, password) values(?, ? , ?)",
+                user.getId(), user.getName(), user.getPassword());
+    }
+
+
+    public User get(String id) {
+        return this.jdbcTemplate.queryForObject("select * from users where id = ?", new Object[]{id}, userMapper);
+    }
+
+    public List<User> getAll() {
+        return this.jdbcTemplate.query("select * from users order by id", userMapper);
+    }
+
+
+    public void deleteAll() {
+        this.jdbcTemplate.update(new PreparedStatementCreator() {
+            @Override
+            public PreparedStatement createPreparedStatement(Connection con) throws SQLException {
+                return con.prepareStatement("delete from users");
+            }
+        });
+
+//        미리 준비된 콜백을 만들어서 템플릿을 호출하는 것까지 한번에 해주는 메서드가 존재한다.
+//        this.jdbcTemplate.update("delete from users");
+    }
+
+    public int getCount() {
+        // 원래 getCount() 메소드에 있던 코드 중에서 변하는 부분만 콜백으로 만들어져서 제공된다고 생각하면 이해하기 쉽다.
+        return this.jdbcTemplate.query(new PreparedStatementCreator() {
+            @Override
+            public PreparedStatement createPreparedStatement(Connection con) throws SQLException {
+                return con.prepareStatement("select count(*) from users");
+            }
+        }, new ResultSetExtractor<Integer>() {
+            @Override
+            public Integer extractData(ResultSet rs) throws SQLException, DataAccessException {
+                rs.next();
+                return rs.getInt(1);
+            }
+        });
+//        이렇게도 할 수 있다.
+//        return this.jdbcTemplate.queryForObject("select count(*) from users", Integer.class);
+    }
+}

--- a/src/springbook/user/dao/UserDaoTest.java
+++ b/src/springbook/user/dao/UserDaoTest.java
@@ -7,10 +7,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
+import org.springframework.jdbc.support.SQLExceptionTranslator;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import springbook.user.domain.User;
 
+import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -22,6 +25,8 @@ import static org.junit.Assert.assertThat;
 public class UserDaoTest {
     @Autowired
     private UserDao dao;
+    @Autowired
+    private DataSource dataSource;
     private User user1;
     private User user2;
 
@@ -120,6 +125,22 @@ public class UserDaoTest {
         dao.add(user1);
     }
 
+    @Test
+    public void sqlExceptionTranslate() {
+        dao.deleteAll();
+        try {
+            dao.add(user1);
+            dao.add(user1);
+        } catch (DuplicateKeyException e) {
+            SQLException sqlEx = (SQLException) e.getRootCause();
+
+            // SQLExceptionTranslator는 `스프링`의 예외 전환 인터페이스!
+            SQLExceptionTranslator set = new SQLErrorCodeSQLExceptionTranslator(this.dataSource);
+
+            // 이제 예외 전환 API를 적용했을 때 DuplicateKeyException이 만들어지는지 보면된다.
+            assertThat(set.translate(null, null, sqlEx), is(DuplicateKeyException.class));
+        }
+    }
     private void checkSameUser(User user1, User user2) {
         assertThat(user1.getId(), is(user2.getId()));
         assertThat(user1.getName(), is(user2.getName()));

--- a/src/springbook/user/dao/UserDaoTest.java
+++ b/src/springbook/user/dao/UserDaoTest.java
@@ -2,8 +2,11 @@ package springbook.user.dao;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import springbook.user.domain.User;
 
 import java.sql.SQLException;
@@ -12,7 +15,10 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = "/test-applicationContext.xml")
 public class UserDaoTest {
+    @Autowired
     private UserDao dao;
     private User user1;
     private User user2;
@@ -21,8 +27,6 @@ public class UserDaoTest {
 
     @Before
     public void setUp() {
-        dao = new UserDao();
-        dao.setDataSource(new SingleConnectionDataSource("jdbc:mysql://localhost/testdb", "root", "rkdudmysql4_", true));
         this.user1 = new User("aaaa", "운가용", "sleep");
         this.user2 = new User("aaab", "로지지징", "gohome");
         this.user3 = new User("aaac", "메롱", "iiii");

--- a/src/springbook/user/dao/UserDaoTest.java
+++ b/src/springbook/user/dao/UserDaoTest.java
@@ -4,6 +4,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -100,6 +102,22 @@ public class UserDaoTest {
         checkSameUser(user1, users1.get(0));
         checkSameUser(user2, users2.get(1));
         checkSameUser(user3, users3.get(2));
+    }
+
+    @Test(expected = DataAccessException.class)
+    public void duplicateKeyThrowsDataAccessException() {
+        dao.deleteAll();
+
+        dao.add(user1);
+        dao.add(user1);
+    }
+
+    @Test(expected = DuplicateKeyException.class)
+    public void duplicateKeyThrowsDuplicateKeyException() {
+        dao.deleteAll();
+
+        dao.add(user1);
+        dao.add(user1);
     }
 
     private void checkSameUser(User user1, User user2) {

--- a/src/test-applicationContext.xml
+++ b/src/test-applicationContext.xml
@@ -13,7 +13,7 @@
         <property name="username" value="root"/>
         <property name="password" value="rkdudmysql4_"/>
     </bean>
-    <bean id="userDao" class="springbook.user.dao.UserDao">
+    <bean id="userDao" class="springbook.user.dao.UserDaoJdbc">
         <property name="dataSource" ref="dataSource"/>
     </bean>
 </beans>


### PR DESCRIPTION
필자는 항상 복구할 수 있는 예외가 아니라면 일단 언체크 예외로 만드는 경향이 있다고 함.

> 언체크 예외라도 필요하다면 **얼마든지 catch블록으로 잡아서 복구/처리**할 수 있다. 하지만 대개는 복구 불가능한 상황이고 보나마나 `RuntimeException`으로 포장해서 던져야 할테니 아예 API 차원에서 런타임 예외를 던지도록 만드는 것이다.

- 커스텀 예외를 런타임예외로 두었을 경우, 예외가 어디서 던져지는지는 표기를 하면 좋겠찌?
  - 어디서든 잡아서 처리할 수 있으면 됨요 
  - 코틀린에서는 `@Throws` 를 쓰면되겠다

## 중첩 예외 만들기

```java
public class DuplicateUserIdException extends RuntimeException {
    public DupicateUserIdException(Throwable cause) {
        super(cause);
    }
}
```

