### PR TITLE
5장 서비스 추상화 - 5.1 사용자 레벨 관리 기능 추가

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="@localhost" uuid="418c50b6-3ed7-4809-8487-27e20d192f83">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3306</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/.idea/git_toolbox_prj.xml
+++ b/.idea/git_toolbox_prj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxProjectSettings">
+    <option name="commitMessageIssueKeyValidationOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+    <option name="commitMessageValidationEnabledOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+  </component>
+</project>

--- a/src/applicationContext.xml
+++ b/src/applicationContext.xml
@@ -12,8 +12,11 @@
         <property name="username" value="root"/>
         <property name="password" value="rkdudmysql4_"/>
     </bean>
+    <bean id="userLevelPolicy" class="springbook.user.service.UserLevelUpgradePolicyImpl">
+    </bean>
     <bean id="userService" class="springbook.user.service.UserService">
         <property name="userDao" ref="userDao" />
+        <property name="userLevelUpgradePolicy" ref="userLevelPolicy"/>
     </bean>
     <bean id="userDao" class="springbook.user.dao.UserDaoJdbc">
         <property name="dataSource" ref="dataSource"/> <!--아직 dao의 get()메서드가 dataSource를 사용하므로 지우지 않음-->

--- a/src/applicationContext.xml
+++ b/src/applicationContext.xml
@@ -12,6 +12,9 @@
         <property name="username" value="root"/>
         <property name="password" value="rkdudmysql4_"/>
     </bean>
+    <bean id="userService" class="springbook.user.service.UserService">
+        <property name="userDao" ref="userDao" />
+    </bean>
     <bean id="userDao" class="springbook.user.dao.UserDaoJdbc">
         <property name="dataSource" ref="dataSource"/> <!--아직 dao의 get()메서드가 dataSource를 사용하므로 지우지 않음-->
     </bean>

--- a/src/springbook/sql/user_create.sql
+++ b/src/springbook/sql/user_create.sql
@@ -1,6 +1,9 @@
 create table users
 (
-    id       varchar(10) primary key,
-    name     varchar(20) not null,
-    password varchar(10) not null
+    id        varchar(10) primary key,
+    name      varchar(20) not null,
+    password  varchar(10) not null,
+    level     tinyint     not null,
+    login     int         not null,
+    recommend int         not null
 );

--- a/src/springbook/user/dao/UserDao.java
+++ b/src/springbook/user/dao/UserDao.java
@@ -7,6 +7,7 @@ import java.util.List;
 public interface UserDao {
     void add(User user);
     User get(String id);
+    public void update(User user);
     List<User> getAll();
     void deleteAll();
     int getCount();

--- a/src/springbook/user/dao/UserDaoJdbc.java
+++ b/src/springbook/user/dao/UserDaoJdbc.java
@@ -39,7 +39,7 @@ public class UserDaoJdbc implements UserDao {
 
 
     public void add(final User user) {
-        this.jdbcTemplate.update("insert into users(id, name, password, level, login, recommend) values(?, ? , ?,?,?)",
+        this.jdbcTemplate.update("insert into users(id, name, password, level, login, recommend) values(?, ? , ?,?,?, ?)",
                 user.getId(), user.getName(), user.getPassword(), user.getLevel().intValue(), user.getLogin(), user.getRecommend());
     }
 
@@ -52,6 +52,14 @@ public class UserDaoJdbc implements UserDao {
         return this.jdbcTemplate.query("select * from users order by id", userMapper);
     }
 
+    @Override
+    public void update(User user) {
+        this.jdbcTemplate.update(
+                "update users set name = ?, password = ?, level = ?, login = ?," +
+                "recommend = ? where id = ?", user.getName(), user.getPassword(),
+                user.getLevel().intValue(), user.getLogin(), user.getRecommend(),
+                user.getId());
+    }
 
     public void deleteAll() {
         this.jdbcTemplate.update(new PreparedStatementCreator() {

--- a/src/springbook/user/dao/UserDaoJdbc.java
+++ b/src/springbook/user/dao/UserDaoJdbc.java
@@ -5,6 +5,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementCreator;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
+import springbook.user.domain.Level;
 import springbook.user.domain.User;
 
 import javax.sql.DataSource;
@@ -29,14 +30,17 @@ public class UserDaoJdbc implements UserDao {
             user.setId(rs.getString("id"));
             user.setName(rs.getString("name"));
             user.setPassword(rs.getString("password"));
+            user.setLevel(Level.valueOf(rs.getInt("level")));
+            user.setLogin(rs.getInt("login"));
+            user.setRecommend(rs.getInt("recommend"));
             return user;
         }
     };
 
 
     public void add(final User user) {
-        this.jdbcTemplate.update("insert into users(id, name, password) values(?, ? , ?)",
-                user.getId(), user.getName(), user.getPassword());
+        this.jdbcTemplate.update("insert into users(id, name, password, level, login, recommend) values(?, ? , ?,?,?)",
+                user.getId(), user.getName(), user.getPassword(), user.getLevel().intValue(), user.getLogin(), user.getRecommend());
     }
 
 

--- a/src/springbook/user/dao/UserDaoTest.java
+++ b/src/springbook/user/dao/UserDaoTest.java
@@ -138,6 +138,31 @@ public class UserDaoTest {
         }
     }
 
+    @Test
+    public void update()
+    {
+        dao.deleteAll();
+        dao.add(user1);
+
+        /**
+         * 만약 유저가 하나 뿐이라면 where절이 없더라도 테스트는 통과할 것이다
+         * 원하는 유저 외의 정보는 변하지 않았음을 검증하도록한다.
+         */
+        dao.add(user2);
+
+        user1.setName("파스쿠찌");
+        user1.setPassword("springno6");
+        user1.setLevel(Level.GOLD);
+        user1.setLogin(1000);
+        user1.setRecommend(999);
+        dao.update(user1);
+
+        User user1update = dao.get(user1.getId());
+        checkSameUser(user1, user1update);
+        User user2same = dao.get(user2.getId());
+        checkSameUser(user2, user2same);
+    }
+
     private void checkSameUser(User user1, User user2) {
         assertThat(user1.getId(), is(user2.getId()));
         assertThat(user1.getName(), is(user2.getName()));

--- a/src/springbook/user/dao/UserDaoTest.java
+++ b/src/springbook/user/dao/UserDaoTest.java
@@ -11,6 +11,7 @@ import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
 import org.springframework.jdbc.support.SQLExceptionTranslator;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import springbook.user.domain.Level;
 import springbook.user.domain.User;
 
 import javax.sql.DataSource;
@@ -34,9 +35,9 @@ public class UserDaoTest {
 
     @Before
     public void setUp() {
-        this.user1 = new User("aaaa", "운가용", "sleep");
-        this.user2 = new User("aaab", "로지지징", "gohome");
-        this.user3 = new User("aaac", "메롱", "iiii");
+        this.user1 = new User("aaaa", "운가용", "sleep", Level.BASIC, 1, 0);
+        this.user2 = new User("aaab", "로지지징", "gohome", Level.SILVER, 55, 10);
+        this.user3 = new User("aaac", "메롱", "iiii", Level.GOLD, 100, 40);
     }
 
     @Test // Junit에게 테스트용 메소드임을 알려준다.
@@ -47,19 +48,14 @@ public class UserDaoTest {
         dao.add(user2);
 
         User userget1 = dao.get(user1.getId());
-        assertThat(userget1.getName(), is(user1.getName()));
-        assertThat(userget1.getPassword(), is(user1.getPassword()));
+        checkSameUser(userget1, user1);
 
         User userget2 = dao.get(user2.getId());
-        assertThat(userget2.getName(), is(user2.getName()));
-        assertThat(userget2.getPassword(), is(user2.getPassword()));
+        checkSameUser(userget2, user2);
     }
 
     @Test
-    public void count() throws SQLException, ClassNotFoundException {
-        User user1 = new User("1111", "홍홍홍", "hongzzi");
-        User user2 = new User("2222", "vivian", "vivivivivi");
-        User user3 = new User("33333", "matcha", "jmt");
+    public void count() {
 
         dao.deleteAll();
 
@@ -84,7 +80,7 @@ public class UserDaoTest {
     }
 
     @Test
-    public void getAll() throws SQLException {
+    public void getAll() {
         dao.deleteAll();
 
         List<User> user0 = dao.getAll();
@@ -141,9 +137,13 @@ public class UserDaoTest {
             assertThat(set.translate(null, null, sqlEx), is(DuplicateKeyException.class));
         }
     }
+
     private void checkSameUser(User user1, User user2) {
         assertThat(user1.getId(), is(user2.getId()));
         assertThat(user1.getName(), is(user2.getName()));
         assertThat(user1.getPassword(), is(user2.getPassword()));
+        assertThat(user1.getLevel(), is(user2.getLevel()));
+        assertThat(user1.getLogin(), is(user2.getLogin()));
+        assertThat(user1.getRecommend(), is(user2.getRecommend()));
     }
 }

--- a/src/springbook/user/domain/Level.java
+++ b/src/springbook/user/domain/Level.java
@@ -1,0 +1,28 @@
+package springbook.user.domain;
+
+public enum Level {
+    BASIC(1), SILVER(2), GOLD(3);
+
+    private final int value;
+
+    Level(int value) {
+        this.value = value;
+    }
+
+    public int intValue() {
+        return value;
+    }
+
+    public static Level valueOf(int value) {
+        switch (value) {
+            case 1:
+                return BASIC;
+            case 2:
+                return SILVER;
+            case 3:
+                return GOLD;
+            default:
+                throw new AssertionError("Unknown Error: " + value);
+        }
+    }
+}

--- a/src/springbook/user/domain/Level.java
+++ b/src/springbook/user/domain/Level.java
@@ -1,16 +1,22 @@
 package springbook.user.domain;
 
 public enum Level {
-    BASIC(1), SILVER(2), GOLD(3);
+    GOLD(3, null), SILVER(2, GOLD) , BASIC(1, SILVER);
 
     private final int value;
+    private final Level next;
 
-    Level(int value) {
+    Level(int value, Level next) {
         this.value = value;
+        this.next = next;
     }
 
     public int intValue() {
         return value;
+    }
+
+    public Level nextLevel() {
+        return next;
     }
 
     public static Level valueOf(int value) {

--- a/src/springbook/user/domain/User.java
+++ b/src/springbook/user/domain/User.java
@@ -4,13 +4,20 @@ public class User {
     String id;
     String name;
     String password;
+    Level level;
+    int login;
+    int recommend;
 
-    public User() {}
+    public User() {
+    }
 
-    public User(String id, String name, String password) {
+    public User(String id, String name, String password, Level level, int login, int recommend) {
         this.id = id;
         this.name = name;
         this.password = password;
+        this.level = level;
+        this.login = login;
+        this.recommend = recommend;
     }
 
 
@@ -36,5 +43,29 @@ public class User {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public Level getLevel() {
+        return level;
+    }
+
+    public void setLevel(Level level) {
+        this.level = level;
+    }
+
+    public int getLogin() {
+        return login;
+    }
+
+    public void setLogin(int login) {
+        this.login = login;
+    }
+
+    public int getRecommend() {
+        return recommend;
+    }
+
+    public void setRecommend(int recommend) {
+        this.recommend = recommend;
     }
 }

--- a/src/springbook/user/domain/User.java
+++ b/src/springbook/user/domain/User.java
@@ -68,4 +68,12 @@ public class User {
     public void setRecommend(int recommend) {
         this.recommend = recommend;
     }
+
+    public void upgradeLevel() {
+        Level nextLevel = this.level.nextLevel();
+        if (nextLevel == null) {
+            throw new IllegalStateException(this.level + "은 업그레이드가 불가능합니다");
+        }
+        this.level = nextLevel;
+    }
 }

--- a/src/springbook/user/domain/UserTest.java
+++ b/src/springbook/user/domain/UserTest.java
@@ -1,0 +1,37 @@
+package springbook.user.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class UserTest {
+    User user;
+
+    @Before
+    public void setUp() {
+        user = new User();
+    }
+
+    @Test
+    public void upgradeLevel() {
+        Level[] levels = Level.values();
+        for(Level level: levels) {
+            if (level.nextLevel() == null) continue;
+            user.setLevel(level);
+            user.upgradeLevel();
+            assertThat(user.getLevel(), is(level.nextLevel()));
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void cannotUpgradeLevel() {
+        Level[] levels = Level.values();
+        for(Level level: levels) {
+            if (level.nextLevel() != null) continue;
+            user.setLevel(level);
+            user.upgradeLevel();
+        }
+    }
+}

--- a/src/springbook/user/service/UserLevelUpgradePolicy.java
+++ b/src/springbook/user/service/UserLevelUpgradePolicy.java
@@ -1,0 +1,8 @@
+package springbook.user.service;
+
+import springbook.user.domain.User;
+
+public interface UserLevelUpgradePolicy {
+    boolean canUpgradeLevel(User user);
+    void upgradeLevel(User user);
+}

--- a/src/springbook/user/service/UserLevelUpgradePolicyImpl.java
+++ b/src/springbook/user/service/UserLevelUpgradePolicyImpl.java
@@ -1,0 +1,34 @@
+package springbook.user.service;
+
+import springbook.user.domain.Level;
+import springbook.user.domain.User;
+
+public class UserLevelUpgradePolicyImpl implements UserLevelUpgradePolicy {
+
+    public static final int MIN_LOGCOUNT_FOR_SILVER = 50;
+    public static final int MIN_RECCOMENT_FOR_GOLD = 30;
+
+    @Override
+    public boolean canUpgradeLevel(User user) {
+        Level currentLevel = user.getLevel();
+        switch (currentLevel) {
+            case BASIC:
+                return user.getLogin() >= MIN_LOGCOUNT_FOR_SILVER;
+            case SILVER:
+                return user.getRecommend() >= MIN_RECCOMENT_FOR_GOLD;
+            case GOLD:
+                return false;
+            default:
+                throw new IllegalArgumentException("Unknown level: " + currentLevel);
+        }
+    }
+
+    @Override
+    public void upgradeLevel(User user) {
+        Level nextLevel = user.getLevel().nextLevel();
+        if (nextLevel == null) {
+            throw new IllegalStateException(user.getLevel() + "은 업그레이드가 불가능합니다");
+        }
+        user.upgradeLevel();
+    }
+}

--- a/src/springbook/user/service/UserService.java
+++ b/src/springbook/user/service/UserService.java
@@ -13,6 +13,13 @@ public class UserService {
         this.userDao = userDao;
     }
 
+    public void add(User user) {
+        if (user.getLevel() == null) {
+            user.setLevel(Level.BASIC);
+        }
+        userDao.add(user);
+    }
+
     public void upgradeLevels() {
         List<User> users = userDao.getAll();
         for(User user: users) {

--- a/src/springbook/user/service/UserService.java
+++ b/src/springbook/user/service/UserService.java
@@ -8,9 +8,14 @@ import java.util.List;
 
 public class UserService {
     UserDao userDao;
+    UserLevelUpgradePolicy userLevelUpgradePolicy;
 
     public void setUserDao(UserDao userDao) {
         this.userDao = userDao;
+    }
+
+    public void setUserLevelUpgradePolicy(UserLevelUpgradePolicy userLevelUpgradePolicy) {
+        this.userLevelUpgradePolicy = userLevelUpgradePolicy;
     }
 
     public void add(User user) {
@@ -22,20 +27,11 @@ public class UserService {
 
     public void upgradeLevels() {
         List<User> users = userDao.getAll();
-        for(User user: users) {
-            Boolean changed = null;
-            if (user.getLevel() == Level.BASIC && user.getLogin() >= 50) {
-                user.setLevel(Level.SILVER);
-                changed = true;
-            } else if (user.getLevel() == Level.SILVER && user.getRecommend() >= 30) {
-                user.setLevel(Level.GOLD);
-                changed = true;
-            } else if (user.getLevel() == Level.GOLD) {
-                changed = false;
-            } else {
-                changed = false;
+        for (User user : users) {
+            if (userLevelUpgradePolicy.canUpgradeLevel(user)) {
+                userLevelUpgradePolicy.upgradeLevel(user);
+                userDao.update(user);
             }
-            if (changed) { userDao.update(user); }
         }
     }
 }

--- a/src/springbook/user/service/UserService.java
+++ b/src/springbook/user/service/UserService.java
@@ -1,0 +1,34 @@
+package springbook.user.service;
+
+import springbook.user.dao.UserDao;
+import springbook.user.domain.Level;
+import springbook.user.domain.User;
+
+import java.util.List;
+
+public class UserService {
+    UserDao userDao;
+
+    public void setUserDao(UserDao userDao) {
+        this.userDao = userDao;
+    }
+
+    public void upgradeLevels() {
+        List<User> users = userDao.getAll();
+        for(User user: users) {
+            Boolean changed = null;
+            if (user.getLevel() == Level.BASIC && user.getLogin() >= 50) {
+                user.setLevel(Level.SILVER);
+                changed = true;
+            } else if (user.getLevel() == Level.SILVER && user.getRecommend() >= 30) {
+                user.setLevel(Level.GOLD);
+                changed = true;
+            } else if (user.getLevel() == Level.GOLD) {
+                changed = false;
+            } else {
+                changed = false;
+            }
+            if (changed) { userDao.update(user); }
+        }
+    }
+}

--- a/src/springbook/user/service/UserServiceTest.java
+++ b/src/springbook/user/service/UserServiceTest.java
@@ -53,6 +53,24 @@ public class UserServiceTest {
         checkLevel(users.get(4), Level.GOLD);
     }
 
+    @Test
+    public void add() {
+        userDao.deleteAll();
+
+        User userWithLevel = users.get(4); // GOLD 레벨
+        User userWithoutLevel = users.get(0);
+        userWithoutLevel.setLevel(null);
+
+        userService.add(userWithLevel);
+        userService.add(userWithoutLevel);
+
+        User userWithLevelRead = userDao.get(userWithLevel.getId());
+        User userWithoutLevelRead = userDao.get(userWithoutLevel.getId());
+
+        assertThat(userWithLevelRead.getLevel(), is(userWithLevel.getLevel()));
+        assertThat(userWithoutLevelRead.getLevel(), is(Level.BASIC));
+    }
+
     private void checkLevel(User user, Level expectedLevel) {
         User userUpdate = userDao.get(user.getId());
         assertThat(userUpdate.getLevel(), is(expectedLevel));

--- a/src/springbook/user/service/UserServiceTest.java
+++ b/src/springbook/user/service/UserServiceTest.java
@@ -1,0 +1,67 @@
+package springbook.user.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import springbook.user.dao.UserDao;
+import springbook.user.domain.Level;
+import springbook.user.domain.User;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = "/test-applicationContext.xml")
+public class UserServiceTest {
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    UserDao userDao;
+
+    List<User> users;
+
+    @Before
+    public void setUp() {
+        users = Arrays.asList(
+                new User("kayoung", "윤가영", "p1", Level.BASIC, 49, 0),
+                new User("haneul", "이하늘", "p2", Level.BASIC, 50, 0),
+                new User("oieuoa", "윤실버", "p3", Level.SILVER, 60, 29),
+                new User("silversky", "스카이", "p4", Level.SILVER, 60, 30),
+                new User("blue", "교수님", "p5", Level.GOLD, 100, 100)
+        );
+    }
+
+    @Test
+    public void upgradeLevels() {
+        userDao.deleteAll();
+        for(User user: users) userDao.add(user);
+
+        userService.upgradeLevels();
+
+        checkLevel(users.get(0), Level.BASIC);
+        checkLevel(users.get(1), Level.SILVER);
+        checkLevel(users.get(2), Level.SILVER);
+        checkLevel(users.get(3), Level.GOLD);
+        checkLevel(users.get(4), Level.GOLD);
+    }
+
+    private void checkLevel(User user, Level expectedLevel) {
+        User userUpdate = userDao.get(user.getId());
+        assertThat(userUpdate.getLevel(), is(expectedLevel));
+    }
+
+    @Test
+    public void bean() {
+        assertThat(this.userService, is(notNullValue()));
+    }
+
+
+}

--- a/src/springbook/user/service/UserServiceTest.java
+++ b/src/springbook/user/service/UserServiceTest.java
@@ -14,8 +14,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static springbook.user.service.UserLevelUpgradePolicyImpl.MIN_LOGCOUNT_FOR_SILVER;
+import static springbook.user.service.UserLevelUpgradePolicyImpl.MIN_RECCOMENT_FOR_GOLD;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/test-applicationContext.xml")
@@ -31,26 +32,26 @@ public class UserServiceTest {
     @Before
     public void setUp() {
         users = Arrays.asList(
-                new User("kayoung", "윤가영", "p1", Level.BASIC, 49, 0),
-                new User("haneul", "이하늘", "p2", Level.BASIC, 50, 0),
-                new User("oieuoa", "윤실버", "p3", Level.SILVER, 60, 29),
-                new User("silversky", "스카이", "p4", Level.SILVER, 60, 30),
-                new User("blue", "교수님", "p5", Level.GOLD, 100, 100)
+                new User("kayoung", "윤가영", "p1", Level.BASIC, MIN_LOGCOUNT_FOR_SILVER - 1, 0),
+                new User("haneul", "이하늘", "p2", Level.BASIC, MIN_LOGCOUNT_FOR_SILVER, 0),
+                new User("oieuoa", "윤실버", "p3", Level.SILVER, 60, MIN_RECCOMENT_FOR_GOLD - 1),
+                new User("silversky", "스카이", "p4", Level.SILVER, 60, MIN_RECCOMENT_FOR_GOLD),
+                new User("blue", "교수님", "p5", Level.GOLD, 100, Integer.MAX_VALUE)
         );
     }
 
     @Test
     public void upgradeLevels() {
         userDao.deleteAll();
-        for(User user: users) userDao.add(user);
+        for (User user : users) userDao.add(user);
 
         userService.upgradeLevels();
 
-        checkLevel(users.get(0), Level.BASIC);
-        checkLevel(users.get(1), Level.SILVER);
-        checkLevel(users.get(2), Level.SILVER);
-        checkLevel(users.get(3), Level.GOLD);
-        checkLevel(users.get(4), Level.GOLD);
+        checkLevelUpgraded(users.get(0), false);
+        checkLevelUpgraded(users.get(1), true);
+        checkLevelUpgraded(users.get(2), false);
+        checkLevelUpgraded(users.get(3), true);
+        checkLevelUpgraded(users.get(4), false);
     }
 
     @Test
@@ -71,15 +72,14 @@ public class UserServiceTest {
         assertThat(userWithoutLevelRead.getLevel(), is(Level.BASIC));
     }
 
-    private void checkLevel(User user, Level expectedLevel) {
+    // 레벨 체크는 Level에 책임이 있어유 여기서 안해도 됨
+    private void checkLevelUpgraded(User user, Boolean upgraded) {
         User userUpdate = userDao.get(user.getId());
-        assertThat(userUpdate.getLevel(), is(expectedLevel));
+        if (upgraded) {
+            assertThat(userUpdate.getLevel(), is(user.getLevel().nextLevel()));
+        } else {
+            assertThat(userUpdate.getLevel(), is(user.getLevel()));
+        }
     }
-
-    @Test
-    public void bean() {
-        assertThat(this.userService, is(notNullValue()));
-    }
-
 
 }

--- a/src/test-applicationContext.xml
+++ b/src/test-applicationContext.xml
@@ -13,8 +13,11 @@
         <property name="username" value="root"/>
         <property name="password" value="rkdudmysql4_"/>
     </bean>
+    <bean id="userLevelPolicy" class="springbook.user.service.UserLevelUpgradePolicyImpl">
+    </bean>
     <bean id="userService" class="springbook.user.service.UserService">
         <property name="userDao" ref="userDao" />
+        <property name="userLevelUpgradePolicy" ref="userLevelPolicy"/>
     </bean>
     <bean id="userDao" class="springbook.user.dao.UserDaoJdbc">
         <property name="dataSource" ref="dataSource"/>

--- a/src/test-applicationContext.xml
+++ b/src/test-applicationContext.xml
@@ -13,6 +13,9 @@
         <property name="username" value="root"/>
         <property name="password" value="rkdudmysql4_"/>
     </bean>
+    <bean id="userService" class="springbook.user.service.UserService">
+        <property name="userDao" ref="userDao" />
+    </bean>
     <bean id="userDao" class="springbook.user.dao.UserDaoJdbc">
         <property name="dataSource" ref="dataSource"/>
     </bean>


### PR DESCRIPTION
이번 주차는 5.1절만 다루었어요!

---

## 사용자 레벨 관리 기능 추가

지금까지 만들었던 UserDao는 User 오브젝트에 담겨있는 사용자 정보에 대한 CRUD 기능만을 가지고 있다.
사용자 정보를 DB에 넣고 빼는 것을 제외하면 어떤 비즈니스 로직도 갖고 있지 않다.

여기에 다음 요구사항을 충족하는 비즈니스 로직을 추가해본다.

### 기능 요구사항

- 사용자의 레벨은 `BASIC`, `SILVER`, `GOLD` 세 가지 중 하나다.
- 사용자가 처음 가입하면 `BASIC` 레벨이 되며, 이후 활동에 따라서 한 단계씩 업그레이드될 수 있다.
- 가입 후 50회 이상 로그인을 하면 `BASIC`에서 `SILVER` 레벨이 된다.
- `SILVER` 레벨이면서 30번 이상 추천을 받으면 `GOLD` 레벨이 된다.
- 사용자 레벨의 변경 작업은 일정한 주기를 가지고 일괄적으로 진행된다. 변경 작업 전에는 조건을 충족하더라도 레벨의 변경이 일어나지 않는다.

\>__<

